### PR TITLE
For advanced_roadmap issue #4418. relation to user_reads fixed. 

### DIFF
--- a/lib/unread_issues/issue_patch.rb
+++ b/lib/unread_issues/issue_patch.rb
@@ -7,7 +7,7 @@ module UnreadIssues
 
       base.class_eval do
         has_many :issue_reads, :dependent=>:delete_all
-        has_one :user_read, :class_name => 'IssueRead', :foreign_key => 'issue_id', :conditions => lambda{|*args| "user_id=#{User.current.id}" }
+        has_one :user_read, :class_name => 'IssueRead', :foreign_key => 'issue_id', :conditions => lambda{|*args| "#{IssueRead.table_name}.user_id=#{User.current.id}" }
         alias_method_chain :css_classes, :unread_issues
       end
     end


### PR DESCRIPTION
Posibility of ambigous columns in some cases when selected via .includes()
